### PR TITLE
fix to run with mcclim-2021

### DIFF
--- a/chess.lisp
+++ b/chess.lisp
@@ -52,8 +52,7 @@
   (:panes
    (board (make-pane 'board-pane
                      :display-function 'draw-board
-                     :incremental-redisplay t
-                     :scroll-bars nil))
+                     :incremental-redisplay t))
    (status :application
            :scroll-bars nil
            :incremental-redisplay t
@@ -223,7 +222,8 @@
 
 (define-chess-command (com-retract :name t) ()
   (let ((board (find-board)))
-    (retract-move board (pop (moves board)))))
+    (retract-last-move board)))
+
 
 (defun poll-engine (frame pane)
   (let ((engine (engine pane)))


### PR DESCRIPTION
Hi,
in the last version of mcclim you cannot use ":scroll-bars nil" as option in a subclass of application-pane.
I also fix a bug "retract-move" function does not exist.
Best Regards,
Alessandro